### PR TITLE
Replace createOwnedItem

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -118,7 +118,7 @@ export class ElectricBastionlandActorSheet extends ActorSheet {
         delete itemData.data["type"];
 
         // Finally, create the item!
-        return this.actor.createOwnedItem(itemData);
+        return this.actor.createEmbeddedDocuments("item", [itemData]);
     }
 
     /**

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -45,16 +45,15 @@ export class ElectricBastionlandActorSheet extends ActorSheet {
 
         // Update Inventory Item
         html.find('.item-edit').click(ev => {
-            const li = $(ev.currentTarget).parents(".item");
-            const item = this.actor.getOwnedItem(li.data("itemId"));
+            const li = $(ev.currentTarget).parents(".item")[0];
+            const item = this.actor.items.get(li.dataset.itemId);
             item.sheet.render(true);
         });
 
         // Delete Inventory Item
         html.find('.item-delete').click(ev => {
-            const li = $(ev.currentTarget).parents(".item");
-            this.actor.deleteOwnedItem(li.data("itemId"));
-            li.slideUp(200, () => this.render(false));
+            const li = $(ev.currentTarget).parents(".item")[0];
+            this.actor.deleteEmbeddedDocuments("Item", [li.dataset.itemId]);
         });
 
         html.find(".item-create").click(this._onItemCreate.bind(this));
@@ -118,7 +117,7 @@ export class ElectricBastionlandActorSheet extends ActorSheet {
         delete itemData.data["type"];
 
         // Finally, create the item!
-        return this.actor.createOwnedItem(itemData);
+        return this.actor.createEmbeddedDocuments("Item", [itemData]);
     }
 
     /**
@@ -134,8 +133,9 @@ export class ElectricBastionlandActorSheet extends ActorSheet {
         if (dataset.roll) {
             let roll = new Roll(dataset.roll, this.actor.data.data);
             let label = dataset.label ? `Rolling ${dataset.label}` : '';
+            roll.roll({ async: false });
 
-            roll.roll().toMessage({
+            roll.toMessage({
                 speaker: ChatMessage.getSpeaker({actor: this.actor}),
                 flavor: label,
             });

--- a/module/electricbastionland.js
+++ b/module/electricbastionland.js
@@ -23,8 +23,8 @@ Hooks.once('init', async function () {
     };
 
     // Define custom Entity classes
-    CONFIG.Actor.entityClass = ElectricBastionlandActor;
-    CONFIG.Item.entityClass = ElectricBastionlandItem;
+    CONFIG.Actor.documentClass = ElectricBastionlandActor;
+    CONFIG.Item.documentClass = ElectricBastionlandItem;
 
 
     // If you need to add Handlebars helpers, here are a few useful examples:
@@ -49,4 +49,3 @@ Hooks.once('init', async function () {
     });
 
 });
-

--- a/system.json
+++ b/system.json
@@ -7,9 +7,9 @@
   "url": "https://github.com/mvdleden/electric-bastionland-FoundryVTT/",
   "license": "LICENSE.txt",
   "flags": {},
-  "version": "1.1.0",
+  "version": "1.1.1",
   "minimumCoreVersion": "0.8.0",
-  "compatibleCoreVersion": "0.8.5",
+  "compatibleCoreVersion": "9",
   "scripts": [],
   "esmodules": [
     "module/electricbastionland.js"

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -44,14 +44,14 @@
                             </label>
                             <div class="resource-content flexrow flex-center flex-between">
                                 <input
-                                    type="text"
+                                    type="number"
                                     name="data.hp.value"
                                     value="{{systemData.hp.value}}"
                                     data-dtype="Number"
                                 />
                                 <span> / </span>
                                 <input
-                                    type="text"
+                                    type="number"
                                     name="data.hp.max"
                                     value="{{systemData.hp.max}}"
                                     data-dtype="Number"/>
@@ -65,10 +65,9 @@
                             <input
                                 class="checkbox-block"
                                 type="checkbox"
-                                {{checked
-                                data.deprived}}
+                                {{checked data.data.deprived}}
                                 name="data.deprived"
-                                value="{{data.deprived}}"
+                                value="{{data.data.deprived}}"
                                 data-dtype="Boolean"/>
                         </div>
                     </div>
@@ -82,7 +81,7 @@
                                 class="resource-label">&#163;</label>
                             <div class="resource-content flexrow flex-center flex-between">
                                 <input
-                                    type="text"
+                                    type="number"
                                     name="data.pounds"
                                     value="{{systemData.pounds}}"
                                     data-dtype="Number"
@@ -121,13 +120,13 @@
                     </label>
                     <div class="flexrow">
                         <input
-                            type="text"
+                            type="number"
                             name="data.abilities.{{key}}.value"
                             value="{{ability.value}}"
                             data-dtype="Number"
                         /> <span> / </span>
                         <input
-                            type="text"
+                            type="number"
                             name="data.abilities.{{key}}.max"
                             value="{{ability.max}}"
                             data-dtype="Number"
@@ -139,19 +138,20 @@
         </div>
     </div>
     <div class="grid grid-3col">
-        {{#unless systemData.deprived}}
         <span>
 			<button
                 type="button"
                 title="Rest"
+                {{#if systemData.deprived}}
+                disabled="true"
+                {{/if}}
                 class="rest">Rest
 			</button>
 		</span>
-        {{/unless}}
         <span>
 			<button
                 type="button"
-                title="Rest"
+                title="Restore Abilities"
                 class="restore">Restore Abilities
 			</button>
 		</span>
@@ -219,7 +219,7 @@
                 {{#each actor.items as |item id|}}
                 <li
                     class="item flexrow"
-                    data-item-id="{{item._id}}">
+                    data-item-id="{{item.id}}">
 					<span>
 						<span class="item-name item-edit">
 							{{item.data.quantity}}
@@ -265,4 +265,3 @@
         </div>
     </section>
 </form>
-

--- a/templates/item/item-sheet.html
+++ b/templates/item/item-sheet.html
@@ -19,8 +19,7 @@
                     <input
                         class="checkbox-block"
                         type="checkbox"
-                        {{checked
-                        systemData.bulky}}
+                        {{checked systemData.bulky}}
                         name="data.bulky"
                         value="{{systemData.bulky}}"
                         data-dtype="Boolean"/>
@@ -30,8 +29,7 @@
                     <input
                         class="checkbox-block"
                         type="checkbox"
-                        {{checked
-                        systemData.equipped}}
+                        {{checked systemData.equipped}}
                         name="data.equipped"
                         value="{{systemData.equipped}}"
                         data-dtype="Boolean"/>
@@ -43,8 +41,7 @@
                     <input
                         class="checkbox-block"
                         type="checkbox"
-                        {{checked
-                        systemData.blast}}
+                        {{checked systemData.blast}}
                         name="data.blast"
                         value="{{systemData.blast}}"
                         data-dtype="Boolean"/>
@@ -58,7 +55,7 @@
         <div class="resource flex-group-center">
             <label class="resource-label">Quantity</label>
             <input
-                type="text"
+                type="number"
                 name="data.quantity"
                 value="{{systemData.quantity}}"
                 data-dtype="Number"/>
@@ -66,7 +63,7 @@
         <div class="resource flex-group-center">
             <label class="resource-label"># of Uses</label>
             <input
-                type="text"
+                type="number"
                 name="data.numberOfUses"
                 value="{{systemData.numberOfUses}}"
                 data-dtype="Number"/>
@@ -74,7 +71,7 @@
         <div class="resource flex-group-center">
             <label class="resource-label">Armour</label>
             <input
-                type="text"
+                type="number"
                 name="data.armour"
                 value="{{systemData.armour}}"
                 data-dtype="Number"/>


### PR DESCRIPTION
Changes the call to `createOwnedItem` in the ElectricBastionlandActorSheet to use
the v9 `createEmbeddedDocuments`.